### PR TITLE
Do not extend tracks list when getting a default value.

### DIFF
--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -85,9 +85,11 @@ class Tracks:
 
     def get_track(self, name):
         """Return the Track for the given track name."""
-        if name not in self._tracks:
-            self._tracks[name] = self.track_handlers[name].default()
-        return self._tracks[name]
+        return (
+            self._tracks[name]
+            if name in self._tracks
+            else self.track_handlers[name].default()
+        )
 
     def items(self):
         """Return the track_name: Track mapping."""

--- a/tests/abstract/test_data.py
+++ b/tests/abstract/test_data.py
@@ -82,6 +82,16 @@ def test_Placeholder():
     assert p1 != p2
 
 
+def test_cache():
+    i = data.AbstractAtom({"interface": int})
+    assert str(i) == "*int()"
+
+    print(i.tracks.value)
+
+    j = data.AbstractAtom({"interface": int})
+    assert str(j) == "*int()"
+
+
 def test_repr():
     i = data.AbstractAtom({"interface": int})
     assert str(i) == "*int()"


### PR DESCRIPTION
Hi @breuleux , this is a fix to make tests pass.

I still don't know exactly why, but the failing test was `tests.abstract.test_data.test_repr` in this assertion:
```python
    i = data.AbstractAtom({"interface": int})
    assert str(i) == "*int()"
```

`str(i)` returned unexpected `*int(value ↦ ANYTHING)`, as if `value` track was read at a moment from `i`. But I can confirm that `i` contained only `interface` track. So, I guessed that the issue should come abstract value caching related to `__eqkey__` method. Then I noticed that method `Track.get_track(self, name)` will extend track dict with given name and a default value if name was not already in tracks.

So, we could have a scenario when:
- a previous `data.AbstractAtom({"interface": int})` was created, then cached using only `interface` track
- then `value` track might be retrieved from this abstract, so that, internal track dict is extended with `value` entry, but cache won't be updated, as abstract is already cached.
- then, when a new `data.AbstractAtom({"interface": int})` is created, it will be associated to the old cached abstract, which, in fact, now contains `interface` and `value` tracks, not only `interface` track, but is cached with same key based on `interface` as the new abstract.

My fix consists of not extending track dict when calling `get_track()`. Now `get_track()` just returns either existing value or default value, without modifing anything.

I don't know why whole tests worked before my PR and no yet after, but this fix seems to solve the issue.

What do you think ?